### PR TITLE
PostID and upVote

### DIFF
--- a/src/AppContext.js
+++ b/src/AppContext.js
@@ -10,6 +10,7 @@ const INITIAL_STATE = {
     roomKey: null,
     posts: [],
     users: [],
+    upVotes: [],
     search_phrase: '',
     filter_by: '',
     admin: false
@@ -40,6 +41,9 @@ const reducer = produce((draft, action) => {
         case 'admin-granted':
             draft.admin = true;
             break;
+        case 'update-upVotes':
+            draft.upVotes = action.upVotes;
+            break;
     }
 
 }, INITIAL_STATE)
@@ -62,11 +66,11 @@ export const API = {
     updatePost: (postUpdate, groupID) => {
         socket.emit('update-post', { postUpdate, groupID });
     },
-    removePost: (title, groupID) => {
-        socket.emit('remove-post', {title, groupID});
+    removePost: (postID, groupID) => {
+        socket.emit('remove-post', {postID, groupID});
     },
-    addComment: (comment, postTitle, groupID) => {
-        socket.emit('add-comment', {comment, postTitle, groupID});
+    addComment: (comment, postID, groupID) => {
+        socket.emit('add-comment', {comment, postID, groupID});
     },
     updateComment: (commentUpdate, groupID) => {
         socket.emit('update-comment', {commentUpdate, groupID});

--- a/src/Views/PostComments.js
+++ b/src/Views/PostComments.js
@@ -10,12 +10,11 @@ import Col from 'react-bootstrap/Col';
 import { BsChevronUp, BsChatSquareDots, BsArrowLeft } from 'react-icons/bs'
 
 function PostComments(props) {
-    const { state: contextState } = useContext(AppContext);
+    const { state: contextState, dispatch } = useContext(AppContext);
     const [content, setContent] = useState("");
     const [time, setTime] = useState(new Date());
     const [anonymous, setAnonymous] = useState(false);
     const [displayForm, setDisplayForm] = useState(false);
-    const [canUpvote, setCanUpvote] = useState(true);
 
     //Handles submission of new Comment
     const handleSubmitForm = (e) => {
@@ -28,19 +27,19 @@ function PostComments(props) {
             isAnon: anonymous
         };
 
-        API.addComment(comment, props.post.title, contextState.roomKey);
+        API.addComment(comment, props.post.id, contextState.roomKey);
         setDisplayForm(false);
         setAnonymous(false);
     };
 
     function handleUpvote() {
-        if (canUpvote) {
+        if (!contextState.upVotes.includes(props.post.id)) {
             const postUpdate = {
-                title: props.post.title,
+                postID: props.post.id,
                 upVote: 1,
             }
             API.updatePost(postUpdate, contextState.roomKey);
-            setCanUpvote(false);
+            dispatch({type: 'update-upVotes', upVotes: contextState.upVotes.push([props.post.id])})
         }
     }
 
@@ -83,9 +82,8 @@ function PostComments(props) {
             });
             comments_array = temp;
         }
-
         return (comments_array.length !== 0 ? 
-                comments_array.map((comment, i) => <Comment title={props.post.title} comment={comment} key={i}/>) 
+                comments_array.map((comment, i) => <Comment postID={props.post.id} comment={comment} key={i}/>) 
                 : <p>No comments yet</p>);
     }
 

--- a/src/components/Comment.js
+++ b/src/components/Comment.js
@@ -11,7 +11,6 @@ import Modal from 'react-bootstrap/Modal';
 import { BsChevronUp } from 'react-icons/bs'
 
 function Comment(props) {
-    const [canUpvote, setCanUpvote] = useState(true)
     const [show, setShow] = useState(false);
     const { state: contextState, dispatch } = useContext(AppContext);
 
@@ -19,20 +18,21 @@ function Comment(props) {
     const handleShow = () => setShow(true);
 
     function handleUpvote() {
-        if (canUpvote) {
+        if (!contextState.upVotes.includes(props.comment.id)) {
             const commentUpdate = {
-                title: props.title,
+                postID: props.postID,
                 commentID: props.comment.id,
                 upVote: 1,
             }
+            console.log(commentUpdate)
             API.updateComment(commentUpdate, contextState.roomKey);
-            setCanUpvote(false);
+            dispatch({type: 'update-upVotes', upVotes: contextState.upVotes.concat([props.comment.id])});
         }
     }
 
     function handleRemove() {
         const removeComment = {
-            title: props.title,
+            postID: props.postID,
             commentID: props.comment.id
         }
         API.removeComment(removeComment,  contextState.roomKey);

--- a/src/components/PostSummary.js
+++ b/src/components/PostSummary.js
@@ -20,18 +20,18 @@ function PostSummary(props) {
     const handleShow = () => setShow(true);
 
     function handleUpvote() {
-        if (canUpvote) {
+        if (!contextState.upVotes.includes(props.post.id)) {
             const postUpdate = {
-                title: props.post.title,
+                postID: props.post.id,
                 upVote: 1,
             }
             API.updatePost(postUpdate, contextState.roomKey);
-            setCanUpvote(false);
+            dispatch({type: 'update-upVotes', upVotes: contextState.upVotes.concat([props.post.id])})
         }
     }
 
     function handleRemove() {
-        API.removePost(props.post.title, contextState.roomKey);
+        API.removePost(props.post.id, contextState.roomKey);
     }
 
     function calculateTime() {


### PR DESCRIPTION
Handle the backend change of Posts identified by id instead of title in the messages sent from the client. Made a list of upvoted posts/comments by client to keep track and make sure they can't upvote it multiple times. Anytime a post/comment is upvoted by the client I add the id to the list.