### PR TITLE
Add attachment name

### DIFF
--- a/src/components/NewPost.js
+++ b/src/components/NewPost.js
@@ -15,6 +15,7 @@ function NewPost(props) {
     const [tag, updateTag] = useState("")
     const [displayError, updateDisplayError] = useState(false)
     const [tagList, updateTagList] = useState([])
+    const [attachmentName, updateAttachmentName] = useState("");
 
     const handleSubmitForm = (e) => {
         updateTime(new Date())
@@ -27,6 +28,8 @@ function NewPost(props) {
             time: time,
             isAnon: anonymous,
             tags: tagList,
+            attachment: attachment,
+            attachmentName: attachmentName,
         }
 
         API.createPost(post, contextState.roomKey)
@@ -63,7 +66,8 @@ function NewPost(props) {
     }
 
     const handleAttachment = (e) => {
-        updateAttachment(e.target.value);
+        updateAttachmentName(e.target.files[0].name)
+        updateAttachment(e.target.files[0]);
     }
 
     const handleAnonymousCheck = (e) => {

--- a/src/components/PostSummary.js
+++ b/src/components/PostSummary.js
@@ -36,6 +36,26 @@ function PostSummary(props) {
         }
     }
 
+    function displayFile() {
+        if (props.post.attachment ==  null) {
+            return null;
+        }
+        else {
+            var ab = new ArrayBuffer(props.post.attachment.data.length);
+            var view = new Uint8Array(ab);
+            for (var i = 0; i < props.post.attachment.data.length; ++i) {
+                view[i] = props.post.attachment.data[i];
+            }
+            console.log(view);
+            const blob = new Blob([view]);
+            console.log(blob);
+            const fileDownloadURL = URL.createObjectURL(blob);
+            return (
+                <a download={props.post.attachmentName} href={fileDownloadURL}>{props.post.attachmentName}</a>
+            )
+        }
+    }
+
     return (
         <animated.div style={props.animated} className="m-4 py-4 postSummary shadow-md rounded-md border border-light">
             <div className="flex">
@@ -63,7 +83,11 @@ function PostSummary(props) {
                         <PostHeader post={props.post} />
                     </div>
                     <div className="divide-y">
-                        <div className="mx-4 my-2 break-all">{props.post.content}</div>
+                        <div className="mx-4 my-2 break-all">
+                            {props.post.content}
+                            <br />
+                            {displayFile()}
+                        </div>
                         <blockquote>
                             <div className="ml-2 mt-2">
                                 <div>


### PR DESCRIPTION
Saves inputted file as file object and includes it with post when create-post call is made. Takes Buffer file object and creates a link under post content that users can click on to download file.

![image](https://user-images.githubusercontent.com/35986321/115130269-627d9f00-9fbc-11eb-955d-0c843f89bbf9.png)

I decided to go with this approach vs. displaying the file within the post to allow for all types of files to be uploaded including videos and pdfs.